### PR TITLE
Update package.json

### DIFF
--- a/web/backend/package.json
+++ b/web/backend/package.json
@@ -10,7 +10,7 @@
     "build": "tsc --skipLibCheck",
     "prepare": "npx prisma generate",
     "prisma:migrate": "npx prisma migrate deploy",
-    "serve": "cross-env NODE_ENV=production node dist/index.js",
+    "serve": "cross-env NODE_ENV=production node --experimental-specifier-resolution=node dist/index.js",
     "start": "npm run prisma:migrate && npm run serve",
     "test": "vitest --reporter=verbose",
     "coverage": "vitest run --coverage",


### PR DESCRIPTION
When backend app is transpiled to js and I want to serve it:

Steps
```
➜  shopify-ts-app cd web/backend 
➜  backend npm run build

> shopify-app-template-node@1.0.0 build
> tsc --skipLibCheck

➜  backend npm run serve

> shopify-app-template-node@1.0.0 serve
> cross-env NODE_ENV=production node dist/index.js

node:internal/errors:490
    ErrorCaptureStackTrace(err);
    ^

Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/Users/vanley/src/shopify-ts-app/web/backend/dist/shopify' imported from /Users/vanley/src/shopify-ts-app/web/backend/dist/index.js
    at new NodeError (node:internal/errors:399:5)
    at finalizeResolution (node:internal/modules/esm/resolve:231:11)
    at moduleResolve (node:internal/modules/esm/resolve:850:10)
    at defaultResolve (node:internal/modules/esm/resolve:1058:11)
    at nextResolve (node:internal/modules/esm/hooks:654:28)
    at Hooks.resolve (node:internal/modules/esm/hooks:309:30)
    at ESMLoader.resolve (node:internal/modules/esm/loader:312:26)
    at ESMLoader.getModuleJob (node:internal/modules/esm/loader:172:38)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:76:40)
    at link (node:internal/modules/esm/module_job:75:36) {
  code: 'ERR_MODULE_NOT_FOUND'
}

Node.js v19.8.1
```

modifying serve command to:
`"serve": "cross-env NODE_ENV=production node --experimental-specifier-resolution=node dist/index.js",`

It's not really a long-term fix just a temporary patch 
nodeJS v19 drops support for --es-module-specifier-resolution=node

Any better ideas?